### PR TITLE
Use strip to avoid nil result

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,10 @@
 language: ruby
 sudo: false
 cache: bundler
-before_install: gem install bundler -v 1.11.2
+before_install: gem install bundler
 rvm:
-  - 2.0.0
-  - 2.1.0
-  - 2.2.0
-  - 2.3.0
+  - 2.2.5
+  - 2.3.1
 addons:
   code_climate:
     repo_token: 134e1f1cc8b60db4f2a491152c9227a6dbbfbeba5c1d05ee8b44cd78a1069f28

--- a/lib/faraday/response/decode_tradevan.rb
+++ b/lib/faraday/response/decode_tradevan.rb
@@ -30,7 +30,7 @@ module Faraday
       cipher.padding = 0
 
       decrypted = cipher.update(Base64.decode64(content)) + cipher.final
-      JSON.load(decrypted.strip!)
+      JSON.load(decrypted.strip)
     end
   end
 end


### PR DESCRIPTION
According to [Ruby's API doc](https://ruby-doc.org/core-2.3.1/String.html#method-i-strip-21) of `strip!`:

> Removes leading and trailing whitespace from str. Returns nil if str was not altered.