### PR TITLE
Use GitHub Actions cron task to auto update donation unit

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -1,0 +1,17 @@
+name: Daily update
+on:
+  schedule:
+    - cron: 0 0 * * *
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-ruby@v1
+    - name: bundle and run rake update
+      run: |
+        bundle install --jobs 4 --retry 3
+        bundle exec rake update_donation_unit
+    - uses: mikeal/publish-to-github-action@master
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
As titled, just need to merge in this PR and no additional configuration on UI is required.

Ref:
- [Sample commit](https://github.com/dlackty/einvoice/commit/11c1a81ad3766b74a2c910afde763760b3b98080) from this GitHub Actions config
- [Sample build lod](https://github.com/dlackty/einvoice/runs/1339701122?check_suite_focus=true)