### PR TITLE
receiverAddrZip max size 5 -> 6

### DIFF
--- a/lib/einvoice/tradevan/model/issue_data.rb
+++ b/lib/einvoice/tradevan/model/issue_data.rb
@@ -102,7 +102,7 @@ module Einvoice
 
         # Type I R G A
         validates :receiverName, allow_blank: true, length: { maximum: 30 }, if: proc { %w(I R G A).include?(self.type) }
-        validates :receiverAddrZip, allow_blank: true, length: { maximum: 5 }, if: proc { %w(I R G A).include?(self.type) }
+        validates :receiverAddrZip, allow_blank: true, length: { maximum: 6 }, if: proc { %w(I R G A).include?(self.type) }
         validates :receiverAddrRoad, allow_blank: true, length: { maximum: 100 }, if: proc { %w(I R G A).include?(self.type) }
         validates :receiverEmail, allow_blank: true, length: { maximum: 80 }, if: proc { %w(I R G A).include?(self.type) }
         validates :receiverMobile, allow_blank: true, length: { maximum: 15 }, if: proc { %w(I R G A).include?(self.type) }

--- a/spec/einvoice/tradevan/model/issue_data_spec.rb
+++ b/spec/einvoice/tradevan/model/issue_data_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe Einvoice::Tradevan::Model::IssueData, type: :model do
       it { is_expected.to validate_presence_of(:carrierIdHidden) }
       it { is_expected.to validate_length_of(:carrierIdHidden).is_at_most(64) }
       it { is_expected.to validate_length_of(:receiverName).is_at_most(30) }
-      it { is_expected.to validate_length_of(:receiverAddrZip).is_at_most(5) }
+      it { is_expected.to validate_length_of(:receiverAddrZip).is_at_most(6) }
       it { is_expected.to validate_length_of(:receiverAddrRoad).is_at_most(100) }
       it { is_expected.to validate_length_of(:receiverEmail).is_at_most(80) }
       it { is_expected.to validate_length_of(:receiverMobile).is_at_most(15) }
@@ -87,7 +87,7 @@ RSpec.describe Einvoice::Tradevan::Model::IssueData, type: :model do
       it { is_expected.to validate_presence_of(:carrierIdHidden) }
       it { is_expected.to validate_length_of(:carrierIdHidden).is_at_most(64) }
       it { is_expected.to validate_length_of(:receiverName).is_at_most(30) }
-      it { is_expected.to validate_length_of(:receiverAddrZip).is_at_most(5) }
+      it { is_expected.to validate_length_of(:receiverAddrZip).is_at_most(6) }
       it { is_expected.to validate_length_of(:receiverAddrRoad).is_at_most(100) }
       it { is_expected.to validate_length_of(:receiverEmail).is_at_most(80) }
       it { is_expected.to validate_length_of(:receiverMobile).is_at_most(15) }
@@ -113,7 +113,7 @@ RSpec.describe Einvoice::Tradevan::Model::IssueData, type: :model do
       it { is_expected.to validate_presence_of(:carrierIdHidden) }
       it { is_expected.to validate_length_of(:carrierIdHidden).is_at_most(64) }
       it { is_expected.to validate_length_of(:receiverName).is_at_most(30) }
-      it { is_expected.to validate_length_of(:receiverAddrZip).is_at_most(5) }
+      it { is_expected.to validate_length_of(:receiverAddrZip).is_at_most(6) }
       it { is_expected.to validate_length_of(:receiverAddrRoad).is_at_most(100) }
       it { is_expected.to validate_length_of(:receiverEmail).is_at_most(80) }
       it { is_expected.to validate_length_of(:receiverMobile).is_at_most(15) }


### PR DESCRIPTION
On March 2, 2020, the Chunghwa Post announced the implementation of a new postal code system called "3+3 postal codes" to enhance mail processing efficiency. 